### PR TITLE
Updated to Clion 2019.3 Api + Renamed Test Configurations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,14 +23,16 @@ tasks.withType(JavaCompile) {
 }
 
 intellij {
-    version '2019.2'
+    version '2019.3'
     type 'CL'
-    alternativeIdePath clionHome
+ //   alternativeIdePath clionHome
     pluginName 'cuda-run-patcher'
+    plugins 'clion-test-google','clion-test-boost','clion-test-catch'
 }
 
+
 patchPluginXml {
-    sinceBuild '192'
+    sinceBuild '193'
 
     changeNotes """
       <em>1.0.0</em><br/>

--- a/src/main/java/CMakeRunPatcherAppRunConfiguration.java
+++ b/src/main/java/CMakeRunPatcherAppRunConfiguration.java
@@ -102,7 +102,8 @@ public class CMakeRunPatcherAppRunConfiguration extends CMakeAppRunConfiguration
                         sourcesMap,
                         productFile,
                         configuration.getBuildWorkingDir(),
-                        configuration.getTargetType()
+                        configuration.getTargetType(),
+                        configuration.getGenerator()
                 );
 
                 method = patchedConfiguration.getClass().getDeclaredMethod("initTarget", CMakeTarget.class);

--- a/src/main/java/CMakeRunPatcherBoostTestRunConfigurationType.java
+++ b/src/main/java/CMakeRunPatcherBoostTestRunConfigurationType.java
@@ -10,14 +10,15 @@ import com.jetbrains.cidr.execution.testing.CidrBeforeTestRunTaskProvider;
 import com.jetbrains.cidr.execution.testing.boost.CidrBoostTestRunConfigurationData;
 import com.jetbrains.cidr.execution.testing.boost.CidrBoostTestRunConfigurationEditor;
 import icons.CidrLangIcons;
+import icons.CidrBoostIcons;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-
+import com.jetbrains.cidr.execution.testing.boost.*;
 // replaces com.jetbrains.cidr.cpp.execution.testing.boost.CMakeBoostTestRunConfigurationType
 
 public class CMakeRunPatcherBoostTestRunConfigurationType extends CMakeRunConfigurationType implements CidrBeforeTestRunTaskProvider.CidrBeforeRunTaskConverter {
     protected CMakeRunPatcherBoostTestRunConfigurationType() {
-        super("CMakeBoostTestRunConfigurationType", "Boost Test", CidrBundle.message("boost.test.configuration.name", new Object[0]), CidrBundle.message("boost.test.configuration.description", new Object[0]), NotNullLazyValue.createValue(() -> CidrLangIcons.BoostTest));
+        super("CMakeBoostTestRunConfigurationType", "Boost Test", CidrBundle.message("boost.test.configuration.name", new Object[0]), CidrBundle.message("boost.test.configuration.description", new Object[0]), NotNullLazyValue.createValue(() -> CidrBoostIcons.BoostTest));
     }
 
     @NotNull

--- a/src/main/java/CMakeRunPatcherBoostTestRunConfigurationType.java
+++ b/src/main/java/CMakeRunPatcherBoostTestRunConfigurationType.java
@@ -18,13 +18,13 @@ import com.jetbrains.cidr.execution.testing.boost.*;
 
 public class CMakeRunPatcherBoostTestRunConfigurationType extends CMakeRunConfigurationType implements CidrBeforeTestRunTaskProvider.CidrBeforeRunTaskConverter {
     protected CMakeRunPatcherBoostTestRunConfigurationType() {
-        super("CMakeBoostTestRunConfigurationType", "Boost Test", CidrBundle.message("boost.test.configuration.name", new Object[0]), CidrBundle.message("boost.test.configuration.description", new Object[0]), NotNullLazyValue.createValue(() -> CidrBoostIcons.BoostTest));
+        super("CMakeBoostTestRunConfigurationType", "Boost Test", "Boost Test Cuda", "Boost Test with Cuda Enabled", NotNullLazyValue.createValue(() -> CidrBoostIcons.BoostTest));
     }
 
     @NotNull
     @Contract("_, _ -> new")
     protected CMakeAppRunConfiguration createRunConfiguration(@NotNull Project project, @NotNull ConfigurationFactory factory) {
-        return new CMakeRunPatcherTestRunConfiguration(project, factory, "", CidrBoostTestRunConfigurationData.FACTORY);
+        return new CMakeRunPatcherTestRunConfiguration(project, factory, "Cuda Boost Test", CidrBoostTestRunConfigurationData.FACTORY);
     }
 
     @NotNull

--- a/src/main/java/CMakeRunPatcherCatchTestRunConfigurationType.java
+++ b/src/main/java/CMakeRunPatcherCatchTestRunConfigurationType.java
@@ -10,6 +10,7 @@ import com.jetbrains.cidr.execution.testing.CidrBeforeTestRunTaskProvider;
 import com.jetbrains.cidr.execution.testing.tcatch.CidrCatchTestRunConfigurationData;
 import com.jetbrains.cidr.execution.testing.tcatch.CidrCatchTestRunConfigurationEditor;
 import icons.CidrLangIcons;
+import icons.CidrCatchIcons;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class CMakeRunPatcherCatchTestRunConfigurationType extends CMakeRunConfigurationType implements CidrBeforeTestRunTaskProvider.CidrBeforeRunTaskConverter {
     protected CMakeRunPatcherCatchTestRunConfigurationType() {
-        super("CMakeCatchTestRunConfigurationType", "Catch Test", CidrBundle.message("catch.test.configuration.name", new Object[0]), CidrBundle.message("catch.test.configuration.description", new Object[0]), NotNullLazyValue.createValue(() -> CidrLangIcons.CatchTest));
+        super("CMakeCatchTestRunConfigurationType", "Catch Test", CidrBundle.message("Catch Test", new Object[0]), CidrBundle.message("Catch Test configuration", new Object[0]), NotNullLazyValue.createValue(() -> CidrCatchIcons.CatchTest));
     }
 
     @NotNull

--- a/src/main/java/CMakeRunPatcherCatchTestRunConfigurationType.java
+++ b/src/main/java/CMakeRunPatcherCatchTestRunConfigurationType.java
@@ -18,13 +18,13 @@ import org.jetbrains.annotations.NotNull;
 
 public class CMakeRunPatcherCatchTestRunConfigurationType extends CMakeRunConfigurationType implements CidrBeforeTestRunTaskProvider.CidrBeforeRunTaskConverter {
     protected CMakeRunPatcherCatchTestRunConfigurationType() {
-        super("CMakeCatchTestRunConfigurationType", "Catch Test", CidrBundle.message("Catch Test", new Object[0]), CidrBundle.message("Catch Test configuration", new Object[0]), NotNullLazyValue.createValue(() -> CidrCatchIcons.CatchTest));
+        super("CMakeCatchTestRunConfigurationType", "Catch Test", "Catch Test Cuda", "Catch Test with Cuda Enabled", NotNullLazyValue.createValue(() -> CidrCatchIcons.CatchTest));
     }
 
     @NotNull
     @Contract("_, _ -> new")
     protected CMakeAppRunConfiguration createRunConfiguration(@NotNull Project project, @NotNull ConfigurationFactory factory) {
-        return new CMakeRunPatcherTestRunConfiguration(project, factory, "", CidrCatchTestRunConfigurationData.FACTORY);
+        return new CMakeRunPatcherTestRunConfiguration(project, factory, "Cuda Enabled Catch Test", CidrCatchTestRunConfigurationData.FACTORY);
     }
 
     @NotNull

--- a/src/main/java/CMakeRunPatcherGoogleTestRunConfigurationType.java
+++ b/src/main/java/CMakeRunPatcherGoogleTestRunConfigurationType.java
@@ -3,13 +3,11 @@ import com.intellij.execution.configurations.ConfigurationTypeUtil;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NotNullLazyValue;
-import com.jetbrains.cidr.CidrBundle;
 import com.jetbrains.cidr.cpp.execution.CMakeAppRunConfiguration;
 import com.jetbrains.cidr.cpp.execution.CMakeRunConfigurationType;
 import com.jetbrains.cidr.execution.testing.CidrBeforeTestRunTaskProvider;
 import com.jetbrains.cidr.execution.testing.google.CidrGoogleTestRunConfigurationData;
 import com.jetbrains.cidr.execution.testing.google.CidrGoogleTestRunConfigurationEditor;
-import icons.CidrLangIcons;
 import icons.CidrGoogleIcons;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -18,13 +16,13 @@ import org.jetbrains.annotations.NotNull;
 
 public class CMakeRunPatcherGoogleTestRunConfigurationType extends CMakeRunConfigurationType implements CidrBeforeTestRunTaskProvider.CidrBeforeRunTaskConverter {
     protected CMakeRunPatcherGoogleTestRunConfigurationType() {
-        super("CMakeGoogleTestRunConfigurationType", "Google Test", CidrBundle.message("gtest.test.configuration.name", new Object[0]), CidrBundle.message("gtest.test.configuration.description", new Object[0]), NotNullLazyValue.createValue(() -> CidrGoogleIcons.GoogleTest));
+        super("CMakeGoogleTestRunConfigurationType", "Google Test", "Google Test Cuda", "Google Test with Cuda Enabled", NotNullLazyValue.createValue(() -> CidrGoogleIcons.GoogleTest));
     }
 
     @NotNull
     @Contract("_, _ -> new")
     protected CMakeAppRunConfiguration createRunConfiguration(@NotNull Project project, @NotNull ConfigurationFactory factory) {
-        return new CMakeRunPatcherTestRunConfiguration(project, factory, "", CidrGoogleTestRunConfigurationData.FACTORY);
+        return new CMakeRunPatcherTestRunConfiguration(project, factory, "Cuda Enabled GTest", CidrGoogleTestRunConfigurationData.FACTORY);
     }
 
     @NotNull

--- a/src/main/java/CMakeRunPatcherGoogleTestRunConfigurationType.java
+++ b/src/main/java/CMakeRunPatcherGoogleTestRunConfigurationType.java
@@ -10,6 +10,7 @@ import com.jetbrains.cidr.execution.testing.CidrBeforeTestRunTaskProvider;
 import com.jetbrains.cidr.execution.testing.google.CidrGoogleTestRunConfigurationData;
 import com.jetbrains.cidr.execution.testing.google.CidrGoogleTestRunConfigurationEditor;
 import icons.CidrLangIcons;
+import icons.CidrGoogleIcons;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class CMakeRunPatcherGoogleTestRunConfigurationType extends CMakeRunConfigurationType implements CidrBeforeTestRunTaskProvider.CidrBeforeRunTaskConverter {
     protected CMakeRunPatcherGoogleTestRunConfigurationType() {
-        super("CMakeGoogleTestRunConfigurationType", "Google Test", CidrBundle.message("gtest.test.configuration.name", new Object[0]), CidrBundle.message("gtest.test.configuration.description", new Object[0]), NotNullLazyValue.createValue(() -> CidrLangIcons.GoogleTest));
+        super("CMakeGoogleTestRunConfigurationType", "Google Test", CidrBundle.message("gtest.test.configuration.name", new Object[0]), CidrBundle.message("gtest.test.configuration.description", new Object[0]), NotNullLazyValue.createValue(() -> CidrGoogleIcons.GoogleTest));
     }
 
     @NotNull

--- a/src/main/java/CMakeRunPatcherTestRunConfiguration.java
+++ b/src/main/java/CMakeRunPatcherTestRunConfiguration.java
@@ -1,4 +1,5 @@
 import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.CommandLineState;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RuntimeConfigurationException;
@@ -27,7 +28,7 @@ public class CMakeRunPatcherTestRunConfiguration extends CMakeRunPatcherAppRunCo
         return this.myTestData;
     }
 
-    public CidrCommandLineState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment env) {
+    public CommandLineState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment env) {
         return this.createState(env, executor, null);
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,6 +3,9 @@
     <name>CLion CUDA Run Patcher</name>
     <vendor email="anantapalani@gmail.com" url="https://github.com/anantapalani">Ananta Palani</vendor>
     <depends>com.intellij.modules.clion</depends>
+    <depends>org.jetbrains.plugins.clion.test.google</depends>
+    <depends>org.jetbrains.plugins.clion.test.boost</depends>
+    <depends>org.jetbrains.plugins.clion.test.catch</depends>
     <extensions defaultExtensionNs="com.intellij">
         <configurationType implementation="CMakeRunPatcherAppRunConfigurationType"/>
         <configurationType implementation="CMakeRunPatcherBoostTestRunConfigurationType"/>


### PR DESCRIPTION
I only tested the patch for RunApplication and GTests. 
Both run but, Clions TestSuite Gui does not work properly. (It is able to show the results, but i am not able to start a second test by using the Gui)